### PR TITLE
Fixed weapon pickup error

### DIFF
--- a/lua/autorun/server/sv_caf_autostart.lua
+++ b/lua/autorun/server/sv_caf_autostart.lua
@@ -121,9 +121,9 @@ local function LoadAddonStatus( addon, defaultstatus )
 end
 
 local function OnEntitySpawn(ent , enttype , ply)
-	if ent == NULL then
+	if ent:IsValid() ~= true then
 		return
-	end	
+	end
 	ent.caf = ent.caf or {}
 	ent.caf.custom = ent.caf.custom or {}
 	if ent.caf.custom.canreceivedamage == nil then


### PR DESCRIPTION
- Fixed picking up a weapon as soon as it spawns causing an error because the entity wasn't valid anymore